### PR TITLE
空データだった場合の防止　レイアウト&スタイル調整

### DIFF
--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -97,7 +97,15 @@
 }
 
 .l-hero__img {
-  inline-size: calc(327 / var(--base-width) * 100%);
+  position: relative;
+  inline-size: calc(338 / var(--base-width) * 100%);
+  aspect-ratio: 338/349;
+  margin: auto;
+}
+
+.l-hero__img-inner {
+  position: absolute;
+  inset: 0;
   margin: auto;
 }
 
@@ -160,7 +168,14 @@
 }
 
 .l-hero__profile-name {
+  margin-block-end: calc(20px / 2);
   text-align: center;
+}
+
+.l-hero__profile-name-inner {
+  display: inline-block;
+  padding: 0 calc(50px / 2) calc(6px / 2) calc(50px / 2) ;
+  border-bottom: 1.5px dashed var(--text);
 }
 
 .l-hero__profile-name-en {
@@ -173,18 +188,15 @@
 
 .l-hero__profile-name-jp {
   display: inline-block;
-  padding-inline: calc(72px / 2);
-  border-bottom: 1.5px dashed var(--text);
   font-family: var(--font-hiragino);
   font-size: calc(18 * var(--rem-ratio));
   font-weight: var(--font-bold);
   text-align: center;
-  line-height: var(--leading-snug);
+  line-height: var(--leading-tight);
   color: var(--text);
 }
 
 .l-hero__profile-text {
-  margin-block-start: calc(20px / 2);
   padding-inline: calc((40 / 568) * 100%);
   font-family: var(--font-hiragino);
   font-size: calc(14 * var(--rem-ratio));

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -119,7 +119,7 @@
   content: '';
   position: absolute;
   inset-block-start: 0;
-  inset-inline-start: calc(50 / var(--base-width) * 100%);;
+  inset-inline-start: calc(50 / var(--base-width) * 100%);
   display: block;
   inline-size: calc(60 / var(--base-width) * 100%);
   block-size: 1px;
@@ -174,7 +174,8 @@
 
 .l-hero__profile-name-inner {
   display: inline-block;
-  padding: 0 calc(50px / 2) calc(6px / 2) calc(50px / 2) ;
+  padding-block: 0 calc(6px / 2);
+  padding-inline: calc(50px / 2);
   border-bottom: 1.5px dashed var(--text);
 }
 

--- a/src/man/index.html
+++ b/src/man/index.html
@@ -43,13 +43,17 @@
             <p class="l-hero__title-jp js-load">お時間ありがとうございました</p>
           </div>
           <div class="l-hero__img">
-            <img src="images/profile/img_hara_momoka.png" alt="原桃香" width="338" height="349" />
+            <div class="l-hero__img-inner">
+              <img src="images/profile/img_hara_momoka.png" alt="原 桃香" width="338" height="349" />
+            </div>
           </div>
           <div class="l-hero__profile js-load">
             <div class="l-hero__profile-inner js-load">
               <div class="l-hero__profile-name">
-                <p class="l-hero__profile-name-en font-din">momoka_hara</p>
-                <p class="l-hero__profile-name-jp">原 桃香</p>
+                <div class="l-hero__profile-name-inner">
+                  <p class="l-hero__profile-name-en font-din">momoka_hara</p>
+                  <p class="l-hero__profile-name-jp">原 桃香</p>
+                </div>
               </div>
               <p class="l-hero__profile-text">お電話でお話しさせていただきました原でございます。気になるお金回りについて是非色々とお話を聞いてみてください！</p>
             </div>

--- a/src/man/index.html
+++ b/src/man/index.html
@@ -21,13 +21,33 @@
     <link rel="icon" type="image/png" sizes="192x192" href="images/android-icon.png" />
     <!-- css/js -->
     <script>
-      (function(d) {
+      (function (d) {
         var config = {
-          kitId: 'fmv4hbu',
-          scriptTimeout: 3000,
-          async: true
-        },
-        h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f || (a && a !="complete"&&a!="loaded"))return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
+            kitId: 'fmv4hbu',
+            scriptTimeout: 3000,
+            async: true,
+          },
+          h = d.documentElement,
+          t = setTimeout(function () {
+            h.className = h.className.replace(/\bwf-loading\b/g, '') + ' wf-inactive';
+          }, config.scriptTimeout),
+          tk = d.createElement('script'),
+          f = false,
+          s = d.getElementsByTagName('script')[0],
+          a;
+        h.className += ' wf-loading';
+        tk.src = 'https://use.typekit.net/' + config.kitId + '.js';
+        tk.async = true;
+        tk.onload = tk.onreadystatechange = function () {
+          a = this.readyState;
+          if (f || (a && a != 'complete' && a != 'loaded')) return;
+          f = true;
+          clearTimeout(t);
+          try {
+            Typekit.load(config);
+          } catch (e) {}
+        };
+        s.parentNode.insertBefore(tk, s);
       })(document);
     </script>
   </head>

--- a/src/woman/index.html
+++ b/src/woman/index.html
@@ -50,7 +50,7 @@
           <div class="l-hero__profile js-load">
             <div class="l-hero__profile-inner js-load">
               <div class="l-hero__profile-name">
-                <div class="l-hero__profile-name-inner"></div>
+                <div class="l-hero__profile-name-inner">
                   <p class="l-hero__profile-name-en font-futura">momoka_hara</p>
                   <p class="l-hero__profile-name-jp">原 桃香</p>
                 </div>

--- a/src/woman/index.html
+++ b/src/woman/index.html
@@ -43,13 +43,17 @@
             <p class="l-hero__title-jp js-load">お時間ありがとうございました</p>
           </div>
           <div class="l-hero__img">
-            <img src="images/profile/img_hara_momoka.png" alt="原桃香" width="338" height="349" />
+            <div class="l-hero__img-inner">
+              <img src="images/profile/img_hara_momoka.png" alt="原 桃香" width="338" height="349" />
+            </div>
           </div>
           <div class="l-hero__profile js-load">
             <div class="l-hero__profile-inner js-load">
               <div class="l-hero__profile-name">
-                <p class="l-hero__profile-name-en font-futura">momoka_hara</p>
-                <p class="l-hero__profile-name-jp">原 桃香</p>
+                <div class="l-hero__profile-name-inner"></div>
+                  <p class="l-hero__profile-name-en font-futura">momoka_hara</p>
+                  <p class="l-hero__profile-name-jp">原 桃香</p>
+                </div>
               </div>
               <p class="l-hero__profile-text">お電話でお話しさせていただきました原でございます。気になるお金回りについて是非色々とお話を聞いてみてください！</p>
             </div>

--- a/src/woman/index.html
+++ b/src/woman/index.html
@@ -21,13 +21,33 @@
     <link rel="icon" type="image/png" sizes="192x192" href="images/android-icon.png" />
     <!-- css/js -->
     <script>
-      (function(d) {
+      (function (d) {
         var config = {
-          kitId: 'fmv4hbu',
-          scriptTimeout: 3000,
-          async: true
-        },
-        h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f || (a && a !="complete"&&a!="loaded"))return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
+            kitId: 'fmv4hbu',
+            scriptTimeout: 3000,
+            async: true,
+          },
+          h = d.documentElement,
+          t = setTimeout(function () {
+            h.className = h.className.replace(/\bwf-loading\b/g, '') + ' wf-inactive';
+          }, config.scriptTimeout),
+          tk = d.createElement('script'),
+          f = false,
+          s = d.getElementsByTagName('script')[0],
+          a;
+        h.className += ' wf-loading';
+        tk.src = 'https://use.typekit.net/' + config.kitId + '.js';
+        tk.async = true;
+        tk.onload = tk.onreadystatechange = function () {
+          a = this.readyState;
+          if (f || (a && a != 'complete' && a != 'loaded')) return;
+          f = true;
+          clearTimeout(t);
+          try {
+            Typekit.load(config);
+          } catch (e) {}
+        };
+        s.parentNode.insertBefore(tk, s);
       })(document);
     </script>
   </head>


### PR DESCRIPTION
## 実装内容

- WordPressで空データだった場合、プロフィール部分のレイアウトが崩れないようにレイアウトとスタイルを調整した。

## 該当画面URL

https://www.financial-agency.com/service/fp-reservation/社員番号/

## 共有事項

プロフィール部分がWordPressの管理画面から登録・編集できる仕様。

## 残タスク

- [ ] ディスクリプション待ち

